### PR TITLE
Handle error even when response body is empty

### DIFF
--- a/src/functions/handleError.ts
+++ b/src/functions/handleError.ts
@@ -5,8 +5,13 @@ import { Response } from 'node-fetch';
  * @param response The response from the DeepL API.
  */
 export async function handleError(response: Response): Promise<void> {
-  const json = await response.json();
-  if (json.message) console.error(json.message);
+  
+  // Log error message if `message` exists in non empty json body
+  const hasBody = (await response.text()).length;
+  if (hasBody) {
+    const json = await response.json();
+    if (json.message) console.error(json.message);
+  }
 
   switch (response.status) {
     case 400:


### PR DESCRIPTION
Parsing an empty response body to json throws an error `invalid json response body at https://api.deepl.com/v2/translate reason: Unexpected end of JSON input` so does not throw the right error according to the response status.  

It occurs when `auth_key` is not valid, but maybe in other cases