### PR TITLE
Fixing Japanese values

### DIFF
--- a/src/enums/language.ts
+++ b/src/enums/language.ts
@@ -11,6 +11,6 @@ export enum Language {
   Dutch = 'NL',
   Polish = 'PL',
   Russian = 'RU',
-  Japanese = 'JP',
+  Japanese = 'JA',
   Chinese = 'ZH',
 }


### PR DESCRIPTION
Hi 
The target_lang value when using Japanese was different from the official value, so it has been fixed.

https://www.deepl.com/docs-api/other-functions/listing-supported-languages/
<img src=https://user-images.githubusercontent.com/24698894/106596575-912cd180-6598-11eb-9466-707e0399bd25.png  width=400>
